### PR TITLE
res-94: Add alarm config for kinesis and firehose

### DIFF
--- a/lambda/health_package/components/generic_helper.py
+++ b/lambda/health_package/components/generic_helper.py
@@ -123,7 +123,7 @@ class GenericHelper:
         """
         Get single value of statistic and
         """
-        statistic_value = None
+        statistic_value = 0
         metric_stats = cls.get_metric_statistics(metric, rule.Statistic)
         print(str(metric_stats))
 
@@ -131,11 +131,28 @@ class GenericHelper:
             statistic_value = datapoint[rule.Statistic]
 
         threshold = statistic_value * rule.Multiplier
-        if threshold < rule.Minimum:
+        LOG.info(
+            "Baseline threshold: %s * %s = %s",
+            statistic_value,
+            rule.Multiplier,
+            threshold
+        )
+        # The min/max overrides do not have to be set
+        # If they are set they override the calculated
+        # threshold value
+        if "Minimum" in rule and threshold < rule.Minimum:
+            LOG.info(
+                "Baseline threshold (%n) is less than rule min (%n)",
+                threshold,
+                rule.Minimum
+            )
             threshold = rule.Minimum
-        elif threshold > rule.Maximum:
+        elif "Maximum" in rule and threshold > rule.Maximum:
+            LOG.info(
+                "Baseline threshold (%n) is greater than rule max (%n)",
+                threshold,
+                rule.Minimum
+            )
             threshold = rule.Maximum
-
-        print(f"Threshold: {statistic_value} * {rule.Multiplier} = {threshold}")
 
         return threshold

--- a/lambda/health_package/format_terraform.py
+++ b/lambda/health_package/format_terraform.py
@@ -43,8 +43,12 @@ def get_tf_item(source, indent_size, indent_level=0):
         formatted += f"\"{source}\""
     elif isinstance(source, int):
         formatted += f"{source}"
+    elif isinstance(source, float):
+        formatted += f"{source}"
     elif source is None:
         formatted += f"\"\""
+    else:
+        print(str(type(source)))
     return formatted
 
 

--- a/terraform/per_account/deployable/cloudwatch_forwarder_lambda.tf
+++ b/terraform/per_account/deployable/cloudwatch_forwarder_lambda.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "cloudwatch_forwarder_euw2_lambda" {
   source_code_hash  = filebase64sha256(local.zipfile)
   function_name     = "cloudwatch_forwarder"
   role              = aws_iam_role.cloudwatch_forwarder_role.arn
-  handler           = "lambda_handler.lambda_handler"
+  handler           = "lambda_handler.cloudwatch_event_handler"
   runtime           = "python3.7"
   timeout           = 6
 

--- a/terraform/per_account/deployable/firehose__ThrottledGetShardIterator.tf
+++ b/terraform/per_account/deployable/firehose__ThrottledGetShardIterator.tf
@@ -1,10 +1,10 @@
-variable "eu-west-1__firehose__ThrottledGetSharditerator" {
+variable "eu-west-1__firehose__ThrottledGetShardIterator" {
   description = "List of metrics derived from aws cloudwatch list-metrics"
   type        = list
   default     = []
 }
 
-variable "eu-west-2__firehose__ThrottledGetSharditerator" {
+variable "eu-west-2__firehose__ThrottledGetShardIterator" {
   description = "List of metrics derived from aws cloudwatch list-metrics"
   type        = list
   default     = []
@@ -12,19 +12,19 @@ variable "eu-west-2__firehose__ThrottledGetSharditerator" {
 
 resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_throttled_get_shard_iterator" {
   # iterate over count to setup multiple alarms
-  count               = length(var.eu-west-1__firehose__ThrottledGetSharditerator)
+  count               = length(var.eu-west-1__firehose__ThrottledGetShardIterator)
   provider            = aws.eu-west-1
-  alarm_name          = "${var.eu-west-1__firehose__ThrottledGetSharditerator[count.index].ResourceName}_alarm"
+  alarm_name          = "${var.eu-west-1__firehose__ThrottledGetShardIterator[count.index].ResourceName}_alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  threshold           = var.eu-west-1__firehose__ThrottledGetSharditerator[count.index].Threshold
+  threshold           = var.eu-west-1__firehose__ThrottledGetShardIterator[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
   metric_name         = "ThrottledGetSharditerator"
   namespace           = "AWS/Firehose"
   period              = 300
   statistic           = "Maximum"
   dimensions = {
-    DeliveryStreamName = var.eu-west-1__firehose__ThrottledGetSharditerator[count.index].ResourceName
+    DeliveryStreamName = var.eu-west-1__firehose__ThrottledGetShardIterator[count.index].ResourceName
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
@@ -32,19 +32,19 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_throttled_get_s
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_get_shard_iterator" {
   # iterate over count to setup multiple alarms
-  count               = length(var.eu-west-2__firehose__ThrottledGetSharditerator)
+  count               = length(var.eu-west-2__firehose__ThrottledGetShardIterator)
   provider            = aws.eu-west-2
-  alarm_name          = "${var.eu-west-2__firehose__ThrottledGetSharditerator[count.index].ResourceName}_alarm"
+  alarm_name          = "${var.eu-west-2__firehose__ThrottledGetShardIterator[count.index].ResourceName}_alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  threshold           = var.eu-west-2__firehose__ThrottledGetSharditerator[count.index].Threshold
+  threshold           = var.eu-west-2__firehose__ThrottledGetShardIterator[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
   metric_name         = "ThrottledGetSharditerator"
   namespace           = "AWS/Firehose"
   period              = 300
   statistic           = "Maximum"
   dimensions = {
-    DeliveryStreamName = var.eu-west-2__firehose__ThrottledGetSharditerator[count.index].ResourceName
+    DeliveryStreamName = var.eu-west-2__firehose__ThrottledGetShardIterator[count.index].ResourceName
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]

--- a/terraform/per_account/deployable/kinesis__PutRecordSuccess.tf
+++ b/terraform/per_account/deployable/kinesis__PutRecordSuccess.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_put_record_succe
   count               = length(var.eu-west-1__kinesis__PutRecordSuccess)
   provider            = aws.eu-west-1
   alarm_name          = "${var.eu-west-1__kinesis__PutRecordSuccess[count.index].ResourceName}_alarm"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = "LessThanThreshold"
   evaluation_periods  = 2
   threshold           = var.eu-west-1__kinesis__PutRecordSuccess[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."

--- a/terraform/per_dashboard_environment/deployable/iam_forwarder_role.tf
+++ b/terraform/per_dashboard_environment/deployable/iam_forwarder_role.tf
@@ -6,7 +6,8 @@ data "aws_iam_policy_document" "health_monitor_forwarder_assume_role" {
     principals {
       type        = "AWS"
       identifiers = [
-        "arn:aws:iam::${module.reference_accounts.staging}:role/cloudwatch_forwarder_role"
+        "arn:aws:iam::${module.reference_accounts.staging}:role/cloudwatch_forwarder_role",
+        "arn:aws:iam::${module.reference_accounts.csls}:role/cloudwatch_forwarder_role"
       ]
     }
   }


### PR DESCRIPTION
This is deployed to the CLS account forwarding to the test instance of the health monitor. 

Needs switching to prod default env when we're ready to go live. 