### PR TITLE
Change lambda timeout to 300 seconds

### DIFF
--- a/terraform/per_account/deployable/lambda_cloudwatch_metric_forwarder.tf
+++ b/terraform/per_account/deployable/lambda_cloudwatch_metric_forwarder.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "cloudwatch_metric_forwarder_euw1_lambda" {
   role              = aws_iam_role.cloudwatch_forwarder_role.arn
   handler           = "lambda_handler.cloudwatch_metric_event_handler"
   runtime           = "python3.7"
-  timeout           = 30
+  timeout           = 300
 
   environment {
     variables = {


### PR DESCRIPTION
This was because some metrics weren't getting sent to Splunk

paired: @danjoneslf @denizgenc