### PR TITLE
Eng 249

### DIFF
--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -66,3 +66,9 @@ class LambdaHelper(GenericHelper):
         except botocore.exceptions.ClientError as err:
             print(str(err))
         return tags
+
+    @classmethod
+    def get_metric_threshold(cls, metric, rule):
+        threshold = super().get_metric_threshold(metric, rule)
+        # Calculate duration threshold here.
+        return threshold

--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -94,7 +94,7 @@ class LambdaHelper(GenericHelper):
             LOG.info(
                 "Baseline threshold (%s) is greater than rule max (%s)",
                 threshold,
-                rule.Maximum,
+                rule.Minimum,
             )
             threshold = rule.Maximum
         return threshold

--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -94,7 +94,7 @@ class LambdaHelper(GenericHelper):
             LOG.info(
                 "Baseline threshold (%s) is greater than rule max (%s)",
                 threshold,
-                rule.Minimum,
+                rule.Maximum,
             )
             threshold = rule.Maximum
         return threshold

--- a/lambda/health_package/generate_metric_alarms.py
+++ b/lambda/health_package/generate_metric_alarms.py
@@ -330,8 +330,6 @@ if __name__ == "__main__":
                 "Statistic": "Maximum",
                 "Multiplier": 1.1,
                 "Minimum": 3,
-                # Any lambda running for less than 3 secs should be fine
-                "Maximum": 60,
                 # Any lambda running longer than 1 minute probably needs breaking up
             }
         ),

--- a/lambda/health_package/generate_metric_alarms.py
+++ b/lambda/health_package/generate_metric_alarms.py
@@ -330,7 +330,8 @@ if __name__ == "__main__":
                 "Statistic": "Maximum",
                 "Multiplier": 1.1,
                 "Minimum": 3,
-                # Any lambda running longer than 1 minute probably needs breaking up
+                # Any lambda running for less than 3 secs should be fine
+                # The maximum is calculated based on the lambda's timeout.
             }
         ),
     ]


### PR DESCRIPTION
When lambdas timeout it sets their duration alarm threshold to 10% higher than the timeout so it doesn't go off.

Override the class method, get the timeout from the lambda, make the threshold 10% less. Remove hardcoded Max.