### PR TITLE
removing u flag

### DIFF
--- a/concourse/slack-webhook-checker/slack-webhook-checker-pipeline.yml
+++ b/concourse/slack-webhook-checker/slack-webhook-checker-pipeline.yml
@@ -21,7 +21,7 @@ slack_webhook_check_task: &slack_webhook_check_task
   run:
     path: bash
     args:
-    - -eu
+    - -e
     - -c
     - |
       echo "Testing slack webhooks configured in SSM"


### PR DESCRIPTION
This PR removes the -u flag from the bash in the pipeline of the slack webhook as this was causing an error on the base docker image 