### PR TITLE
Switch off slack notifications for metric data

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-03-27T15:49:20Z",
+  "generated_at": "2020-09-11T14:21:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
       }
     ]
   },
-  "version": "0.13.0",
+  "version": "0.13.1",
   "word_list": {
     "file": null,
     "hash": null

--- a/lambda/health_package/cloudwatch_metric_forwarder.py
+++ b/lambda/health_package/cloudwatch_metric_forwarder.py
@@ -120,6 +120,7 @@ def cloudwatch_metric_to_standard_health_data_model(alarm, metric_data=None):
         resource_id=resource_id,
         source_data=alarm,
         metric_data=metric_data,
+        notify_slack=False
     )
 
     LOG.debug("Standardised event: %s", json.dumps(event, default=str))


### PR DESCRIPTION
I suspect the spammy messages in service-health are because it's now sending metric notifications to slack.

We don't need metrics to notify slack. The alarms will notify slack when state changes.