### PR TITLE
Temporarily pin AWS provider to 3.16

### DIFF
--- a/terraform/per_account/deployable/provider.tf
+++ b/terraform/per_account/deployable/provider.tf
@@ -1,3 +1,10 @@
+terraform {
+  required_version = ">= 0.12.19"
+  required_providers {
+    aws = "<= 3.16.0"
+  }
+}
+
 provider "aws" {
   # default
   region = "eu-west-2"


### PR DESCRIPTION
Terraform applies are failing with a code signing AccessDenied error.

See this issue for details:
https://github.com/hashicorp/terraform-provider-aws/issues/16398