### PR TITLE
Rename `/var/lock` to allow BuildKit to build http-api-resource

### DIFF
--- a/docker/http-api-resource/Dockerfile
+++ b/docker/http-api-resource/Dockerfile
@@ -2,6 +2,8 @@ FROM aequitas/http-api-resource
 
 FROM python:3.7-alpine
 
+RUN /bin/sh -c 'mv /var/lock /var/lock-orig'
+
 COPY --from=0 . .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Closes #41

You can test this by running

```
DOCKER_BUILDKIT=1 docker build .
```

against the `master` branch - it will error on step 2 with the message:
```
failed to solve with frontend dockerfile.v0: failed to build LLB: cannot replace to directory /var/lib/docker/.../merged/var/lock with file
```

whereas the same command on this branch will error on the last step (which the regular `docker build` will do as well, i.e. it's not an incompatibility with BuildKit that is the issue).