### PR TITLE
Fix build errors for http-api-resource

### DIFF
--- a/docker/http-api-resource/Dockerfile
+++ b/docker/http-api-resource/Dockerfile
@@ -10,4 +10,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY --from=0 /opt/resource/ /opt/resource/
 COPY --from=0 /opt/resource-tests/ /opt/resource-tests/
 
+RUN pip install --no-cache-dir -r requirements_dev.txt
+RUN isort /opt/resource /opt/resource-tests/
+
 RUN /opt/resource-tests/test.sh


### PR DESCRIPTION
The last line of the Dockerfile runs a test script, which in turn runs `pylama`. As part of pylama's checks, it uses `isort` to check if all the imports in Python files are ordered correctly - this wasn't the case for opt/resource-tests/test_hipchat.py and opt/resource-tests/test_invocation.py, so the script would exit with an error.

To fix this, I install from `requirements_dev.txt` and then run isort on all the directories being tested before the script is run.

This isn't super efficient because the script runs the same `pip install` line, so a bit of time is taken checking packages we've already installed, but it's probably the most elegant and explicit solution.