### PR TITLE
Set metadata to route health events to correct index and set source

### DIFF
--- a/lambda/health_package/splunk_forwarder.py
+++ b/lambda/health_package/splunk_forwarder.py
@@ -10,13 +10,17 @@ SPLUNK_HEC_SSM_PARAMETER = "/health-monitoring/updated-dashboard/splunk-hec-toke
 AWS_REGION = "eu-west-2"
 
 
-def process_update_dashboard_event(event):
+def process_update_dashboard_event(lambda_invoke_event):
     """ Receive and process Health Monitoring message """
     try:
-        health_monitoring_message = json.loads(event["Records"][0]["Sns"]["Message"])
-        LOG.info("Message: %s", str(health_monitoring_message))
-        payload_to_send = build_splunk_payload(health_monitoring_message)
-        send_health_monitoring_data_to_splunk(payload_to_send)
+        health_events = [
+            json.loads(event["Sns"]["Message"])
+            for event in lambda_invoke_event["Records"]
+        ]
+        for health_monitoring_message in health_events:
+            LOG.info("Message: %s", str(health_monitoring_message))
+            payload_to_send = build_splunk_payload(health_monitoring_message)
+            send_health_monitoring_data_to_splunk(payload_to_send)
 
     except (ValueError, KeyError):
         LOG.error("Failed to build Splunk payload for health monitoring data")
@@ -38,9 +42,30 @@ def get_splunk_hec_token(ssm_param, region):
         LOG.error("Failed to retrieve Splunk Cloud HEC token")
 
 
+def get_environment(health_event):
+    """ Get the environment setting from the source event
+
+    Normalise to prod|test to match index names
+    """
+    try:
+        event_env = health_event.get("Environment", "prod")
+    except (KeyError, TypeError):
+        event_env = "prod"
+
+    env = "prod" if event_env in ("prod", "production", "live") else "test"
+    return env
+
+
 def build_splunk_payload(health_monitoring_payload):
     """ Build the Health Monitoring payload to send to Splunk Cloud HEC """
-    payload_dictionary = {"sourcetype": "_json", "event": health_monitoring_payload}
+    env = get_environment(health_monitoring_payload)
+
+    payload_dictionary = {
+        "index": f"cyber_services_{env}",
+        "source": "health_monitoring_event",
+        "sourcetype": "_json",
+        "event": health_monitoring_payload
+    }
 
     payload_to_send = json.dumps(payload_dictionary)
 

--- a/lambda/health_package/splunk_forwarder.py
+++ b/lambda/health_package/splunk_forwarder.py
@@ -22,8 +22,11 @@ def process_update_dashboard_event(lambda_invoke_event):
             payload_to_send = build_splunk_payload(health_monitoring_message)
             send_health_monitoring_data_to_splunk(payload_to_send)
 
-    except (ValueError, KeyError):
-        LOG.error("Failed to build Splunk payload for health monitoring data")
+    except (ValueError, KeyError, JSONDecodeError) as error:
+        LOG.error(
+            "Failed to build Splunk payload for health monitoring data: %s",
+            error
+        )
 
 
 def get_splunk_hec_token(ssm_param, region):
@@ -49,7 +52,7 @@ def get_environment(health_event):
     """
     try:
         event_env = health_event.get("Environment", "prod")
-    except (KeyError, TypeError):
+    except (TypeError):
         event_env = "prod"
 
     env = "prod" if event_env in ("prod", "production", "live") else "test"


### PR DESCRIPTION
DRAFT until 
- [x] eventtypes exist in splunk (https://github.com/alphagov/cyber-security-splunk-apps/pull/565)
- [x] dashboard has been updated to use eventtypes
- [x] existing HEC has permission to cyber service indexes (or switch HEC to one that does)

Currently the health events are being routed to index=csls_dev which
is not ideal.

For now my intention is to route them to cyber_services_prod|test
and set the source field to "health_monitoring_event".

We can then create an eventtype which looks for the data in both
places so we don't lose the old data.