### PR TITLE
Set minimum health threshold for lambda duration to 3000ms

### DIFF
--- a/lambda/health_package/generate_metric_alarms.py
+++ b/lambda/health_package/generate_metric_alarms.py
@@ -329,9 +329,10 @@ if __name__ == "__main__":
                 "MetricName": "Duration",
                 "Statistic": "Maximum",
                 "Multiplier": 1.1,
-                "Minimum": 3,
+                "Minimum": 3000,
                 # Any lambda running for less than 3 secs should be fine
                 # The maximum is calculated based on the lambda's timeout.
+                # This is measured in milliseconds (I think that has changed)
             }
         ),
     ]


### PR DESCRIPTION
Previously set to 3 (assuming it was measured in seconds)