### PR TITLE
Lambda max duration is intended to be 90% of timeout.

### DIFF
--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -94,7 +94,8 @@ class LambdaHelper(GenericHelper):
         except botocore.exceptions.ClientError as err:
             print(str(err))
 
-        rule.Maximum = lambda_timeout * 0.9
+        # 90% of max timeout seconds in milliseconds
+        rule.Maximum = lambda_timeout * 1000 * 0.9
 
         if threshold > rule.Maximum:
             LOG.info(


### PR DESCRIPTION
Timeout is in seconds, duration is measured in milliseconds.
Need to add * 1000 to set 90% of timeout in millis