### PR TITLE
Remove optional unit argument to get-metric-statistics

### DIFF
--- a/lambda/health_package/components/generic_helper.py
+++ b/lambda/health_package/components/generic_helper.py
@@ -114,7 +114,6 @@ class GenericHelper:
             StartTime=days_ago,
             EndTime=now,
             Period=period,
-            Unit="Seconds",
             Statistics=[statistic],
         )
         return Dict(stats_response)


### PR DESCRIPTION
This was resulting in the call returning no data.

This would have caused errors in other metrics but I think was working for Lambda duration but also stopped working when AWS moved from measuring duration in seconds to millis.