### PR TITLE
Rely on metric.Region property rather than passing region around

### DIFF
--- a/lambda/health_package/components/firehose_helper.py
+++ b/lambda/health_package/components/firehose_helper.py
@@ -11,12 +11,13 @@ class FirehoseHelper(GenericHelper):
     """ Helper functions for Firehose """
 
     @classmethod
-    def metric_resource_exists(cls, metric, region=None):
+    def metric_resource_exists(cls, metric):
         """
         Check the resource exists before defining an alarm
         aws cloudwatch list-metrics returns metrics for resources that
         no longer exists
         """
+        region = metric.Region
         namespace = metric.Namespace
         resource_exists = True
         try:
@@ -41,11 +42,12 @@ class FirehoseHelper(GenericHelper):
         return resource_exists
 
     @classmethod
-    def get_tags_for_metric_resource(cls, metric, region=None):
+    def get_tags_for_metric_resource(cls, metric):
         """
         Get QueueUrl from queue name and then get the tags if present
         There is some duplication of the above function it would be nice to remove
         """
+        region = metric.Region
         namespace = metric.Namespace
         tags = {}
         try:

--- a/lambda/health_package/components/kinesis_helper.py
+++ b/lambda/health_package/components/kinesis_helper.py
@@ -11,12 +11,13 @@ class KinesisHelper(GenericHelper):
     """ Helper functions for SQS """
 
     @classmethod
-    def metric_resource_exists(cls, metric, region=None):
+    def metric_resource_exists(cls, metric):
         """
         Check the resource exists before defining an alarm
         aws cloudwatch list-metrics returns metrics for resources that
         no longer exists
         """
+        region = metric.Region
         namespace = metric.Namespace
         resource_exists = True
         try:
@@ -38,11 +39,12 @@ class KinesisHelper(GenericHelper):
         return resource_exists
 
     @classmethod
-    def get_tags_for_metric_resource(cls, metric, region=None):
+    def get_tags_for_metric_resource(cls, metric):
         """
         Get QueueUrl from queue name and then get the tags if present
         There is some duplication of the above function it would be nice to remove
         """
+        region = metric.Region
         namespace = metric.Namespace
         tags = {}
         try:

--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -12,12 +12,13 @@ class LambdaHelper(GenericHelper):
     """ Helper functions for Lambda """
 
     @classmethod
-    def metric_resource_exists(cls, metric, region=None):
+    def metric_resource_exists(cls, metric):
         """
         Check the resource exists before defining an alarm
         aws cloudwatch list-metrics returns metrics for resources that
         no longer exists
         """
+        region = metric.Region
         namespace = metric.Namespace
         resource_exists = True
         try:
@@ -40,11 +41,12 @@ class LambdaHelper(GenericHelper):
         return resource_exists
 
     @classmethod
-    def get_tags_for_metric_resource(cls, metric, region=None):
+    def get_tags_for_metric_resource(cls, metric):
         """
         Get QueueUrl from queue name and then get the tags if present
         There is some duplication of the above function it would be nice to remove
         """
+        region = metric.Region
         namespace = metric.Namespace
         tags = {}
         try:
@@ -69,7 +71,8 @@ class LambdaHelper(GenericHelper):
         return tags
 
     @classmethod
-    def get_metric_threshold(cls, metric, rule, region=None):
+    def get_metric_threshold(cls, metric, rule):
+        region = metric.Region
         threshold = super().get_metric_threshold(metric, rule)
         # Calculate duration threshold here.
 

--- a/lambda/health_package/components/sqs_helper.py
+++ b/lambda/health_package/components/sqs_helper.py
@@ -12,12 +12,13 @@ class SqsHelper(GenericHelper):
     """ Helper functions for SQS """
 
     @classmethod
-    def metric_resource_exists(cls, metric, region=None):
+    def metric_resource_exists(cls, metric):
         """
         Check the resource exists before defining an alarm
         aws cloudwatch list-metrics returns metrics for resources that
         no longer exists
         """
+        region = metric.Region
         namespace = metric.Namespace
         resource_exists = True
         try:
@@ -40,11 +41,12 @@ class SqsHelper(GenericHelper):
         return resource_exists
 
     @classmethod
-    def get_tags_for_metric_resource(cls, metric, region=None):
+    def get_tags_for_metric_resource(cls, metric):
         """
         Get QueueUrl from queue name and then get the tags if present
         There is some duplication of the above function it would be nice to remove
         """
+        region = metric.Region
         namespace = metric.Namespace
         tags = {}
         try:

--- a/lambda/health_package/conftest.py
+++ b/lambda/health_package/conftest.py
@@ -399,7 +399,6 @@ def mock_get_metric_statistics():
                     "Sum": 123.0,
                     "Minimum": 123.0,
                     "Maximum": 123.0,
-                    "Unit": "Seconds",
                 }
             ],
         }

--- a/lambda/health_package/demo/set_alarm_state.py
+++ b/lambda/health_package/demo/set_alarm_state.py
@@ -51,12 +51,12 @@ def toggle_alarm_state(alarm_name, region="eu-west-2"):
         # Set alarm state from Alarm to OK
         print(f"Alarm for {str(alarm_name)} is currently set to {state}")
         set_alarm_state("OK", str(alarm_name), region)
-        print(f"Setting state from ALARM -> OK")
+        print("Setting state from ALARM -> OK")
     elif state == "OK":
         # Set alarm state from OK to ALARM
         print(f"Alarm for {alarm_name} is currently set to {state}")
         set_alarm_state("ALARM", str(alarm_name), region)
-        print(f"Setting state from OK -> ALARM")
+        print("Setting state from OK -> ALARM")
     else:
         # INSUFFICENT_DATA state
         print(f"Alarm state for {alarm_name} is set to {state}")

--- a/lambda/health_package/generate_metric_alarms.py
+++ b/lambda/health_package/generate_metric_alarms.py
@@ -159,7 +159,7 @@ def get_metric_alarms(metrics):
                 print(f"Checking rules for {metric.MetricName}")
                 if (
                     metric.MetricName == metric_rule.MetricName
-                    and helper.metric_resource_exists(metric, region=region)
+                    and helper.metric_resource_exists(metric)
                 ):
                     # get metric-statistics and calculate health threshold
                     metric.Threshold = helper.get_metric_threshold(metric, metric_rule)

--- a/lambda/health_package/tests/stubs.py
+++ b/lambda/health_package/tests/stubs.py
@@ -24,7 +24,6 @@ def mock_cloudwatch(mock_get_metric_statistics):
         "StartTime": ANY,
         "EndTime": ANY,
         "Period": 2419200,
-        "Unit": "Seconds",
         "Statistics": ["Maximum"],
     }
 

--- a/lambda/health_package/tests/test_components_generic_helper.py
+++ b/lambda/health_package/tests/test_components_generic_helper.py
@@ -56,7 +56,6 @@ def test_get_metric_statistics(lambda_metric, mock_get_metric_statistics):
         assert datapoint.Timestamp == "2020-03-27T11:29:51.780Z"
         assert datapoint.Minimum == 123.0
         assert datapoint.Maximum == 123.0
-        assert datapoint.Unit == "Seconds"
 
 
 @pytest.mark.usefixtures("lambda_metric")


### PR DESCRIPTION
Because the script iterates across multiple AWS regions, it has to create clients with the correct region for any given metric. 

Previously that was being done inconsistently by passing the region as method arguments but since Region is a property of the metric that's not necessary.