### PR TITLE
Tag resources created by Terraform

### DIFF
--- a/terraform/per_account/deployable/caller.tf
+++ b/terraform/per_account/deployable/caller.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__DeliveryToS3DataFreshness.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__DeliveryToS3DataFreshness.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_delivery_to_s3_
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__firehose__DeliveryToS3DataFreshness[count.index].ResourceName}_DeliveryToS3DataFreshness_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_delivery_to_s3_data_freshness" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_delivery_to_s3_
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__firehose__DeliveryToS3DataFreshness[count.index].ResourceName}_DeliveryToS3DataFreshness_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__ExecuteProcessingDuration.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__ExecuteProcessingDuration.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_execute_process
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__firehose__ExecuteProcessingDuration[count.index].ResourceName}_ExecuteProcessingDuration_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_execute_processing_duration" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_execute_process
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__firehose__ExecuteProcessingDuration[count.index].ResourceName}_ExecuteProcessingDuration_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__ExecuteProcessingSuccess.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__ExecuteProcessingSuccess.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_execute_process
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__firehose__ExecuteProcessingSuccess[count.index].ResourceName}_ExecuteProcessingSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_execute_processing_success" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_execute_process
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__firehose__ExecuteProcessingSuccess[count.index].ResourceName}_ExecuteProcessingSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__KinesisMillisBehindLatest.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__KinesisMillisBehindLatest.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_millis_behind_la
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__firehose__KinesisMillisBehindLatest[count.index].ResourceName}_KinesisMillisBehindLatest_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_millis_behind_latest" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_millis_behind_la
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__firehose__KinesisMillisBehindLatest[count.index].ResourceName}_KinesisMillisBehindLatest_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__ThrottledGetShardIterator.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__ThrottledGetShardIterator.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_throttled_get_s
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__firehose__ThrottledGetShardIterator[count.index].ResourceName}_ThrottledGetShardIterator_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_get_shard_iterator" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_get_shard_itera
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__firehose__ThrottledGetShardIterator[count.index].ResourceName}_ThrottledGetShardIterator_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsIteratorAgeMilliseconds.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsIteratorAgeMilliseconds.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_get_records_iter
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__GetRecordsIteratorAgeMilliseconds[count.index].ResourceName}_GetRecordsIteratorAgeMilliseconds_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_get_records_iterator_age_msecs" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_get_records_iter
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__GetRecordsIteratorAgeMilliseconds[count.index].ResourceName}_GetRecordsIteratorAgeMilliseconds_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsSuccess.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsSuccess.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_get_records_succ
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__GetRecordsSuccess[count.index].ResourceName}_GetRecordsSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_get_records_success" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_get_records_succ
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__GetRecordsSuccess[count.index].ResourceName}_GetRecordsSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__PutRecordSuccess.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__PutRecordSuccess.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_put_record_succe
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__PutRecordSuccess[count.index].ResourceName}_PutRecordSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_put_record_success" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_put_record_succe
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__PutRecordSuccess[count.index].ResourceName}_PutRecordSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__PutRecordsSuccess.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__PutRecordsSuccess.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_put_records_succ
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__PutRecordsSuccess[count.index].ResourceName}_PutRecordsSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_put_records_success" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_put_records_succ
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__PutRecordsSuccess[count.index].ResourceName}_PutRecordsSuccess_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__ReadProvisionedThroughputExceeded.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__ReadProvisionedThroughputExceeded.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_read_provision_t
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__ReadProvisionedThroughputExceeded[count.index].ResourceName}_ReadProvisionedThroughputExceeded_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_read_provision_throughput_exceeded" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_read_provision_t
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__ReadProvisionedThroughputExceeded[count.index].ResourceName}_ReadProvisionedThroughputExceeded_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__WriteProvisionedThroughputExceeded.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__WriteProvisionedThroughputExceeded.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_write_provision_
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__kinesis__WriteProvisionedThroughputExceeded[count.index].ResourceName}_WriteProvisionedThroughputExceeded_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_write_provision_throughput_exceeded" {
@@ -48,4 +49,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_write_provision_
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__kinesis__WriteProvisionedThroughputExceeded[count.index].ResourceName}_WriteProvisionedThroughputExceeded_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__lambda__Duration.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__lambda__Duration.tf
@@ -29,6 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_lambda_duration" {
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   treat_missing_data  = "notBreaching"
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__lambda__Duration[count.index].ResourceName}_Duration_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_lambda_duration" {
@@ -50,4 +51,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_lambda_duration" {
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   treat_missing_data  = "notBreaching"
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__lambda__Duration[count.index].ResourceName}_Duration_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__lambda__Errors.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__lambda__Errors.tf
@@ -29,6 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_lambda_errors" {
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   treat_missing_data  = "notBreaching"
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__lambda__Errors[count.index].ResourceName}_Errors_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_lambda_errors" {
@@ -50,4 +51,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_lambda_errors" {
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   treat_missing_data  = "notBreaching"
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__lambda__Errors[count.index].ResourceName}_Errors_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateAgeOfOldestMessage.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateAgeOfOldestMessage.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_approx_age" {
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__ApproximateAgeOfOldestMessage[count.index].ResourceName}_ApproximateAgeOfOldestMessage_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -49,5 +50,6 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_approx_age" {
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__ApproximateAgeOfOldestMessage[count.index].ResourceName}_ApproximateAgeOfOldestMessage_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 

--- a/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateNumberOfMessagesNotVisible.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateNumberOfMessagesNotVisible.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_approx_num_of_messag
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__ApproximateNumberOfMessagesNotVisible[count.index].ResourceName}_ApproximateNumberOfMessagesNotVisible_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -49,4 +50,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_approx_num_of_messag
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__ApproximateNumberOfMessagesNotVisible[count.index].ResourceName}_ApproximateNumberOfMessagesNotVisible_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateNumberOfMessagesVisible.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__sqs__ApproximateNumberOfMessagesVisible.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_approx_num_of_messag
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__ApproximateNumberOfMessagesVisible[count.index].ResourceName}_ApproximateNumberOfMessagesVisible_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -49,4 +50,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_approx_num_of_messag
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__ApproximateNumberOfMessagesVisible[count.index].ResourceName}_ApproximateNumberOfMessagesVisible_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__sqs__MaximumMessageSize.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__sqs__MaximumMessageSize.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_sent_message_size" {
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__SentMessageSize[count.index].ResourceName}_SentMessageSize_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -49,4 +50,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_sent_message_size" {
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__SentMessageSize[count.index].ResourceName}_SentMessageSize_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/cloudwatch_alarm__sqs__NumberOfMessagesSent.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__sqs__NumberOfMessagesSent.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_num_of_messages_sent
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__NumberOfMessagesSent[count.index].ResourceName}_NumberOfMessagesSent_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -49,6 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_num_of_messages_sent
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__NumberOfMessagesSent[count.index].ResourceName}_NumberOfMessagesSent_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_num_of_messages_sent_low" {
@@ -69,6 +71,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_sqs_num_of_messages_sent
   }
   alarm_actions       = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw1_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-1__sqs__NumberOfMessagesSent[count.index].ResourceName}_alarm_${data.aws_caller_identity.current.account_id}"))
 }
 
 
@@ -90,4 +93,5 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_sqs_num_of_messages_sent
   }
   alarm_actions       = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
   ok_actions          = ["${local.euw2_sns_cloudwatch_forwarder_topic}"]
+  tags                = merge(module.tags.tags, map("Name", "${var.eu-west-2__sqs__NumberOfMessagesSent[count.index].ResourceName}_alarm_${data.aws_caller_identity.current.account_id}"))
 }

--- a/terraform/per_account/deployable/iam.tf
+++ b/terraform/per_account/deployable/iam.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "cloudwatch_forwarder_assume_role" {
 resource "aws_iam_role" "cloudwatch_forwarder_role" {
   name               = "cloudwatch_forwarder_role"
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_forwarder_assume_role.json
+  tags                = merge(module.tags.tags, map("Name", "cloudwatch_forwarder_role_${data.aws_caller_identity.current.account_id}"))
 }
 
 # Publish events to SNS topic

--- a/terraform/per_account/deployable/lambda_cloudwatch_alarm_forwarder.tf
+++ b/terraform/per_account/deployable/lambda_cloudwatch_alarm_forwarder.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "cloudwatch_alarm_forwarder_euw1_lambda" {
   handler           = "lambda_handler.cloudwatch_alarm_event_handler"
   runtime           = "python3.7"
   timeout           = 30
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_alarm_forwarder_euw1_${data.aws_caller_identity.current.account_id}"))
 
   environment {
     variables = {
@@ -47,6 +48,7 @@ resource "aws_lambda_function" "cloudwatch_alarm_forwarder_euw2_lambda" {
   handler           = "lambda_handler.cloudwatch_alarm_event_handler"
   runtime           = "python3.7"
   timeout           = 30
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_alarm_forwarder_euw2_${data.aws_caller_identity.current.account_id}"))
 
   environment {
     variables = {

--- a/terraform/per_account/deployable/lambda_cloudwatch_metric_forwarder.tf
+++ b/terraform/per_account/deployable/lambda_cloudwatch_metric_forwarder.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "cloudwatch_metric_forwarder_euw1_lambda" {
   handler           = "lambda_handler.cloudwatch_metric_event_handler"
   runtime           = "python3.7"
   timeout           = 300
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_metric_forwarder_euw1_${data.aws_caller_identity.current.account_id}"))
 
   environment {
     variables = {
@@ -27,6 +28,7 @@ resource "aws_cloudwatch_event_rule" "every_hour_euw1" {
   name                = "every-hour"
   description         = "Fires every hour"
   schedule_expression = local.metric_cron
+  tags                = merge(module.tags.tags, map("Name", "every_hour_health_monitoring_euw1_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_event_target" "run_every_hour_euw1" {
@@ -54,6 +56,7 @@ resource "aws_lambda_function" "cloudwatch_metric_forwarder_euw2_lambda" {
   handler           = "lambda_handler.cloudwatch_metric_event_handler"
   runtime           = "python3.7"
   timeout           = 300
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_metric_forwarder_euw2_${data.aws_caller_identity.current.account_id}"))
 
   environment {
     variables = {
@@ -74,6 +77,7 @@ resource "aws_cloudwatch_event_rule" "every_hour_euw2" {
   name                = "every-hour"
   description         = "Fires every hour"
   schedule_expression = local.metric_cron
+  tags                = merge(module.tags.tags, map("Name", "every_hour_health_monitoring_euw2_${data.aws_caller_identity.current.account_id}"))
 }
 
 resource "aws_cloudwatch_event_target" "run_every_hour_euw2" {

--- a/terraform/per_account/deployable/sns.tf
+++ b/terraform/per_account/deployable/sns.tf
@@ -4,6 +4,7 @@ locals {
 resource "aws_sns_topic" "euw1_cloudwatch_alarm_sns_topic" {
   provider  = aws.eu-west-1
   name      = local.cloudwatch_alarm_sns_topic
+  tags      = merge(module.tags.tags, map("Name", "euw1_cloudwatch_alarm_sns_topic_${data.aws_caller_identity.current.account_id}"))
 }
 
 output "euw1_sns_arn" {
@@ -14,6 +15,7 @@ output "euw1_sns_arn" {
 resource "aws_sns_topic" "euw2_cloudwatch_alarm_sns_topic" {
   provider  = aws.eu-west-2
   name      = local.cloudwatch_alarm_sns_topic
+  tags      = merge(module.tags.tags, map("Name", "euw2_cloudwatch_alarm_sns_topic_${data.aws_caller_identity.current.account_id}"))
 }
 
 output "euw2_sns_arn" {

--- a/terraform/per_account/deployable/tags.tf
+++ b/terraform/per_account/deployable/tags.tf
@@ -1,0 +1,4 @@
+module "tags" {
+  source = "../../tags"
+  DEF_ENVIRONMENT = var.DEF_ENVIRONMENT
+}

--- a/terraform/per_dashboard_environment/deployable/health_monitor_lambda.tf
+++ b/terraform/per_dashboard_environment/deployable/health_monitor_lambda.tf
@@ -6,6 +6,7 @@ resource "aws_lambda_function" "health_monitor_lambda" {
   handler          = "lambda_handler.health_monitor_handler"
   timeout          = 60
   runtime          = "python3.7"
+  tags             = merge(module.tags.tags, map("Name", "health_monitor_lambda"))
 
   environment {
     variables = {

--- a/terraform/per_dashboard_environment/deployable/iam.tf
+++ b/terraform/per_dashboard_environment/deployable/iam.tf
@@ -13,11 +13,13 @@ data "aws_iam_policy_document" "health_monitor_assume_role" {
 resource "aws_iam_role" "health_monitor_role" {
   name               = "health_monitor_role"
   assume_role_policy = data.aws_iam_policy_document.health_monitor_assume_role.json
+  tags               = merge(module.tags.tags, map("Name", "health_monitor_role"))
 }
 
 resource "aws_iam_role" "health_monitor_update_dashboard_role" {
   name               = "health_monitor_update_dashboard_role"
   assume_role_policy = data.aws_iam_policy_document.health_monitor_assume_role.json
+  tags               = merge(module.tags.tags, map("Name", "health_monitor_update_dashboard_role"))
 }
 
 # Publish events to SNS topic

--- a/terraform/per_dashboard_environment/deployable/sns_pubs.tf
+++ b/terraform/per_dashboard_environment/deployable/sns_pubs.tf
@@ -8,6 +8,7 @@ resource "aws_sns_topic" "euw1_sns_topics" {
   count    = length(var.sns_topic_names)
   provider = aws.eu-west-1
   name     = var.sns_topic_names[count.index]
+  tags     = merge(module.tags.tags, map("Name", "${var.sns_topic_names[count.index]}"))
 }
 
 output "euw1_sns_arns" {
@@ -24,6 +25,7 @@ resource "aws_sns_topic" "euw2_sns_topics" {
   count    = length(var.sns_topic_names)
   provider = aws.eu-west-2
   name     = var.sns_topic_names[count.index]
+  tags     = merge(module.tags.tags, map("Name", "${var.sns_topic_names[count.index]}"))
 }
 
 output "euw2_sns_arns" {

--- a/terraform/per_dashboard_environment/deployable/sqs_incoming_health_events.tf
+++ b/terraform/per_dashboard_environment/deployable/sqs_incoming_health_events.tf
@@ -1,6 +1,7 @@
 resource "aws_sqs_queue" "incoming_health_events" {
   name                        = "incoming_health_events"
   visibility_timeout_seconds  = 60
+  tags     = merge(module.tags.tags, map("Name", "incoming_health_events"))
 }
 
 data "aws_iam_policy_document" "incoming_health_events_resource_policy_data" {

--- a/terraform/per_dashboard_environment/deployable/tags.tf
+++ b/terraform/per_dashboard_environment/deployable/tags.tf
@@ -1,0 +1,4 @@
+module "tags" {
+  source = "../../tags"
+  DEF_ENVIRONMENT = var.DEF_ENVIRONMENT
+}

--- a/terraform/per_dashboard_environment/deployable/update_dashboard_lambda.tf
+++ b/terraform/per_dashboard_environment/deployable/update_dashboard_lambda.tf
@@ -6,6 +6,7 @@ resource "aws_lambda_function" "health_monitor_update_dashboard_lambda" {
   handler          = "lambda_handler.splunk_forwarder_event_handler"
   timeout          = 60
   runtime          = "python3.7"
+  tags     = merge(module.tags.tags, map("Name", "health_monitor_splunk_forwarder_lambda"))
 }
 
 resource "aws_lambda_permission" "allow_invocation_from_sns" {

--- a/terraform/tags/tags.tf
+++ b/terraform/tags/tags.tf
@@ -1,0 +1,14 @@
+variable "DEF_ENVIRONMENT" {
+    type    = string
+    default = "Test"
+}
+
+output "tags" {
+  value = {
+    Service       = "health"
+    Environment   = var.DEF_ENVIRONMENT
+    SvcOwner      = "cyber.security@digital.cabinet-office.gov.uk"
+    DeployedUsing = "Terraform12"
+    SvcCodeURL    = "https://github.com/alphagov/cyber-security-cloudwatch-config"
+  }
+}


### PR DESCRIPTION
Closes #64 

I created a `tags` module (in `terraform/tags`) so I could cut down on copying and pasting. Hopefully that's fine.

The `DeployedUsing` tag is simply `"Terraform12"` - do we want more detail for that (e.g. `"Terraformv0.12.19"`)? If we do need additional detail, I'm not sure how I'd go about providing that without hardcoding the value (which is brittle). I guess we could pass it in as an input variable, and then set it during Concourse.

Also, as per #64's instruction to "account ID in "Name" tag" for the `per_account` resources, I have added them to the end of  the Name tags. Would it be more convenient to have them at the start of the Name?