### PR TITLE
Fix alarms for Kinesis and Kinesis Firehose

### DIFF
--- a/terraform/per_account/deployable/cloudwatch_alarm__firehose__ThrottledGetShardIterator.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__firehose__ThrottledGetShardIterator.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_firehose_throttled_get_s
   evaluation_periods  = 2
   threshold           = var.eu-west-1__firehose__ThrottledGetShardIterator[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
-  metric_name         = "ThrottledGetSharditerator"
+  metric_name         = "ThrottledGetShardIterator"
   namespace           = "AWS/Firehose"
   period              = 300
   statistic           = "Maximum"
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_firehose_get_shard_itera
   evaluation_periods  = 2
   threshold           = var.eu-west-2__firehose__ThrottledGetShardIterator[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
-  metric_name         = "ThrottledGetSharditerator"
+  metric_name         = "ThrottledGetShardIterator"
   namespace           = "AWS/Firehose"
   period              = 300
   statistic           = "Maximum"

--- a/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsIteratorAgeMilliseconds.tf
+++ b/terraform/per_account/deployable/cloudwatch_alarm__kinesis__GetRecordsIteratorAgeMilliseconds.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "euw1_cloudwatch_kinesis_get_records_iter
   evaluation_periods  = 2
   threshold           = var.eu-west-1__kinesis__GetRecordsIteratorAgeMilliseconds[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
-  metric_name         = "GetRecordsIteratorAgeMilliseconds"
+  metric_name         = "GetRecords.IteratorAgeMilliseconds"
   namespace           = "AWS/Kinesis"
   period              = 300
   statistic           = "Maximum"
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "euw2_cloudwatch_kinesis_get_records_iter
   evaluation_periods  = 2
   threshold           = var.eu-west-2__kinesis__GetRecordsIteratorAgeMilliseconds[count.index].Threshold
   alarm_description   = "Tracks the read position across all shards and consumers in the stream. If an iterator's age passes 50% of the retention period (by default, 24 hours, configurable up to 7 days), there is risk for data loss due to record expiration."
-  metric_name         = "GetRecordsIteratorAgeMilliseconds"
+  metric_name         = "GetRecords.IteratorAgeMilliseconds"
   namespace           = "AWS/Kinesis"
   period              = 300
   statistic           = "Maximum"


### PR DESCRIPTION
Both minor errors in the metric names (missing a full stop in one case, and capitalisation in another)