### PR TITLE
Don't pass unnecessary parameter for get_tags_for_metric_resource

### DIFF
--- a/lambda/health_package/cloudwatch_alarm_forwarder.py
+++ b/lambda/health_package/cloudwatch_alarm_forwarder.py
@@ -27,7 +27,7 @@ def cloudwatch_alarm_to_standard_health_data_model(source_message):
     region = session.region_name
     metric = source_message.Trigger
     helper = enrich.get_namespace_helper(metric.Namespace)
-    source_message.Tags = helper.get_tags_for_metric_resource(metric, region=region)
+    source_message.Tags = helper.get_tags_for_metric_resource(metric)
 
     event = HealthEvent()
 

--- a/lambda/health_package/cloudwatch_metric_forwarder.py
+++ b/lambda/health_package/cloudwatch_metric_forwarder.py
@@ -100,7 +100,7 @@ def cloudwatch_metric_to_standard_health_data_model(alarm, metric_data=None):
     metric.update(alarm.Dimensions)
     helper = enrich.get_namespace_helper(metric.Namespace)
     LOG.debug("Using %s helper", helper.__class__.__name__)
-    tags = helper.get_tags_for_metric_resource(metric, region=region)
+    tags = helper.get_tags_for_metric_resource(metric)
     alarm.Tags = tags
     LOG.debug("Tags: %s", json.dumps(tags))
 


### PR DESCRIPTION
The region parameter was removed in PR #62 - however it's still being passed as an argument here. It's causing `TypeErrors` in the test account:

```
[ERROR] TypeError: get_tags_for_metric_resource() got an unexpected keyword argument 'region'
Traceback (most recent call last):
  File "/var/task/lambda_handler.py", line 25, in cloudwatch_alarm_event_handler
    process_cloudwatch_alarm_event(event)
  File "/var/task/cloudwatch_alarm_forwarder.py", line 16, in process_cloudwatch_alarm_event
    standardised_data = cloudwatch_alarm_to_standard_health_data_model(message)
  File "/var/task/cloudwatch_alarm_forwarder.py", line 30, in cloudwatch_alarm_to_standard_health_data_model
    source_message.Tags = helper.get_tags_for_metric_resource(metric, region=region)
```