### PR TITLE
Fix flake8 errors and Concourse pipeline testing

### DIFF
--- a/concourse/cloudwatch/pipeline.yml
+++ b/concourse/cloudwatch/pipeline.yml
@@ -85,7 +85,6 @@ jobs:
               - |
                 cd lambda/health_package
                 make test
-                echo "Tests completed"
             dir: cyber-security-cloudwatch-config-git
         on_failure:
           <<: *health_status_notify

--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -83,7 +83,10 @@ class LambdaHelper(GenericHelper):
                 print(f"Getting boto client for {namespace} in {region}")
                 client = cls.get_client_from_namespace(namespace, region)
                 if client:
-                    function_name = cls.get_metric_dimension_value(metric, "FunctionName")
+                    function_name = cls.get_metric_dimension_value(
+                        metric,
+                        "FunctionName"
+                    )
                     if function_name:
                         print(f"Get timeout for lambda function: {function_name}")
                         get_function_response = Dict(

--- a/lambda/health_package/components/lambda_helper.py
+++ b/lambda/health_package/components/lambda_helper.py
@@ -5,7 +5,6 @@ import botocore
 from addict import Dict
 
 from components.generic_helper import GenericHelper
-from logger import LOG
 
 
 class LambdaHelper(GenericHelper):


### PR DESCRIPTION
The `cloudwatch_test` job in Concourse would be green even the tests failed because of the last `echo` command. I decided to simply remove it since it's not a very useful message.

76d25a5 fixes `components/lambda_helper.py:8:1: F401 'logger.LOG' imported but unused`
0a2b510 fixes `components/lambda_helper.py:87:89: E501 line too long (90 > 88 characters)`