### PR TITLE
Separate metric-settings into JSON outside generate alarms script

### DIFF
--- a/lambda/health_package/Makefile
+++ b/lambda/health_package/Makefile
@@ -21,6 +21,7 @@ add_dev_deps:
 
 copy_dir:
 	cp *.py .target/
+	cp *.json .target/
 	cp components/*.py .target/components/
 
 build: clean target_dir add_deps copy_dir

--- a/lambda/health_package/generate_metric_alarms.py
+++ b/lambda/health_package/generate_metric_alarms.py
@@ -137,7 +137,8 @@ def get_metric_alarms(metrics):
     alarms = Dict()
 
     # implement standard monitoring rules based on namespace
-    for metric_rule in METRIC_RULES:
+    for metric in METRIC_RULES:
+        metric_rule = Dict(metric)
         namespace = metric_rule.Namespace
         helper = enrich.get_namespace_helper(namespace)
         service = helper.get_namespace_service(namespace)
@@ -242,100 +243,6 @@ if __name__ == "__main__":
     # for 1 datapoints within 5 minutes
     # firehose__DeliveryToS3DataFreshness > 500
     # for 1 datapoints within 5 minutes
-    METRIC_RULES = [
-        Dict(
-            {
-                "Namespace": "AWS/SQS",
-                "MetricName": "ApproximateAgeOfOldestMessage",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 2,
-                "Maximum": 300,  # this is an initial guess to be tuned later
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/SQS",
-                "MetricName": "ApproximateNumberOfMessagesVisible",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 500,
-                "Maximum": 5000,  # this is an initial guess to be tuned later
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Kinesis",
-                "MetricName": "PutRecord.Success",
-                "Statistic": "Minimum",
-                "Multiplier": 1,
-                "Minimum": 0.99,  # alert on 1% failure
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Firehose",
-                "MetricName": "ExecuteProcessing.Success",
-                "Statistic": "Minimum",
-                "Multiplier": 1,
-                "Minimum": 0.99,  # alert on 1% failure
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Kinesis",
-                "MetricName": "GetRecords.IteratorAgeMilliseconds",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 300,
-                "Maximum": 43200000,  # 12 hours
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Firehose",
-                "MetricName": "ThrottledGetShardIterator",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 2,
-                "Maximum": 10,
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Firehose",
-                "MetricName": "KinesisMillisBehindLatest",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 3000,
-                # Not interested in less than 3 seconds delay
-                "Maximum": 60000,
-                # We'd want to know if there was a minute delay in kinesis
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Lambda",
-                "MetricName": "Errors",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 10,
-                # We probably don't want to know the first few times a lambda errors
-                "Maximum": 200,
-                # We definitely want to know if it errors frequently
-            }
-        ),
-        Dict(
-            {
-                "Namespace": "AWS/Lambda",
-                "MetricName": "Duration",
-                "Statistic": "Maximum",
-                "Multiplier": 1.1,
-                "Minimum": 3000,
-                # Any lambda running for less than 3 secs should be fine
-                # The maximum is calculated based on the lambda's timeout.
-                # This is measured in milliseconds (I think that has changed)
-            }
-        ),
-    ]
-    main()
+    with open("metric-settings.json", "r") as metrics_file:
+        METRIC_RULES = json.load(metrics_file)
+        main()

--- a/lambda/health_package/metric-settings.json
+++ b/lambda/health_package/metric-settings.json
@@ -1,0 +1,79 @@
+[
+  {
+    "Namespace": "AWS/SQS",
+    "MetricName": "ApproximateAgeOfOldestMessage",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 2,
+    "Maximum": 300,
+    "Description": "This is an initial guess to be tuned later"
+  },
+  {
+    "Namespace": "AWS/SQS",
+    "MetricName": "ApproximateNumberOfMessagesVisible",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 500,
+    "Maximum": 5000,
+    "Description" : "This is an initial guess to be tuned later"
+  },
+  {
+    "Namespace": "AWS/Kinesis",
+    "MetricName": "PutRecord.Success",
+    "Statistic": "Minimum",
+    "Multiplier": 1,
+    "Minimum": 0.99,
+    "Description": "Alert on 1% failure"
+  },
+  {
+    "Namespace": "AWS/Firehose",
+    "MetricName": "ExecuteProcessing.Success",
+    "Statistic": "Minimum",
+    "Multiplier": 1,
+    "Minimum": 0.99,
+    "Description": "Alert on 1% failure"
+  },
+  {
+    "Namespace": "AWS/Kinesis",
+    "MetricName": "GetRecords.IteratorAgeMilliseconds",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 300,
+    "Maximum": 43200000,
+    "Description": "Maximum 12 hours"
+  },
+  {
+    "Namespace": "AWS/Firehose",
+    "MetricName": "ThrottledGetShardIterator",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 2,
+    "Maximum": 10
+  },
+  {
+    "Namespace": "AWS/Firehose",
+    "MetricName": "KinesisMillisBehindLatest",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 3000,
+    "Maximum": 60000,
+    "Description": "Not interested in less than 3 seconds delay. We'd want to know if there was a minute delay in kinesis."
+  },
+  {
+    "Namespace": "AWS/Lambda",
+    "MetricName": "Errors",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 10,
+    "Maximum": 200,
+    "Description": "We probably don't want to know the first few times a lambda errors. We definitely want to know if it errors frequently."
+  },
+  {
+    "Namespace": "AWS/Lambda",
+    "MetricName": "Duration",
+    "Statistic": "Maximum",
+    "Multiplier": 1.1,
+    "Minimum": 3000,
+    "Description": "Any lambda running for less than 3 secs should be fine. The maximum is calculated based on the lambda's timeout. This is measured in milliseconds (I think that has changed)."
+  }
+]


### PR DESCRIPTION
Moves the list of metric settings out of `generate_metric_alarms.py` into a separate `metric-settings.json` and then wraps each one in `Dict()` when iterating over the list. 

Makes it a bit easier to see where the config is. 