### PR TITLE
Run the tests in a venv and pin version of black

### DIFF
--- a/concourse/cloudwatch/pipeline.yml
+++ b/concourse/cloudwatch/pipeline.yml
@@ -84,6 +84,11 @@ jobs:
               - -c
               - |
                 cd lambda/health_package
+                # Not sure why this venv is necessary
+                # For some reason without it pip install fails
+                pip install virtualenv
+                virtualenv ~/venv
+                . ~/venv/bin/activate
                 make test
             dir: cyber-security-cloudwatch-config-git
         on_failure:

--- a/lambda/health_package/requirements-dev.txt
+++ b/lambda/health_package/requirements-dev.txt
@@ -4,7 +4,7 @@ flake8
 pytest
 tox
 isort
-black
+black==20.8b1
 pytest-flake8
 pytest-isort
 pytest-black


### PR DESCRIPTION
This needs further investigation but for some reason a pip requirements install is not working properly. Even though the way round it is to install virtualenv with pip which does work. 

I've also had to pin the black version since the black tests were passing locally but failing in concourse because of a version mismatch.