### PR TITLE
Create SNS topics and subscriptions for event forwarder

### DIFF
--- a/terraform/per_account/deployable/lambda_cloudwatch_event_rule_forwarder.tf
+++ b/terraform/per_account/deployable/lambda_cloudwatch_event_rule_forwarder.tf
@@ -1,13 +1,13 @@
-resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_lambda" {
-  provider          = aws.eu-west-2
+resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_euw1_lambda" {
+  provider          = aws.eu-west-1
   filename          = local.zipfile
   source_code_hash  = filebase64sha256(local.zipfile)
-  function_name     = "cloudwatch_event_rule_forwarder"
+  function_name     = "cloudwatch_event_rule_forwarder_euw1"
   role              = aws_iam_role.cloudwatch_forwarder_role.arn
   handler           = "lambda_handler.cloudwatch_event_rule_handler"
   runtime           = "python3.7"
   timeout           = 30
-  tags              = merge(module.tags.tags, map("Name", "cloudwatch_event_rule_forwarder_${data.aws_caller_identity.current.account_id}"))
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_event_rule_forwarder_euw1_${data.aws_caller_identity.current.account_id}"))
 
   environment {
     variables = {
@@ -23,20 +23,56 @@ resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_lambda" {
   }
 }
 
-data "aws_sns_topic" "codepipeline_health_notification" {
-  name = "codepipeline-health-notification"
-}
-
-resource "aws_lambda_permission" "cloudwatch_forwarder_codepipeline_sns_invoke" {
+resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw1_sns_invoke" {
   statement_id  = "CloudForwarderCodepipelineAllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.cloudwatch_event_rule_forwarder_lambda.function_name
+  function_name = aws_lambda_function.cloudwatch_event_rule_forwarder_euw1_lambda.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = data.aws_sns_topic.codepipeline_health_notification.arn
+  source_arn    = aws_sns_topic.euw1_cloudwatch_event_sns_topic.arn
 }
 
-resource "aws_sns_topic_subscription" "health_monitor_codepipeline_sns_subscription" {
-  topic_arn = data.aws_sns_topic.codepipeline_health_notification.arn
+resource "aws_sns_topic_subscription" "health_monitor_events_euw1_sns_subscription" {
+  topic_arn = aws_sns_topic.euw1_cloudwatch_event_sns_topic.arn
   protocol  = "lambda"
-  endpoint  = aws_lambda_function.cloudwatch_event_rule_forwarder_lambda.arn
+  endpoint  = aws_lambda_function.cloudwatch_event_rule_forwarder_euw1_lambda.arn
+}
+
+
+resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_euw2_lambda" {
+  provider          = aws.eu-west-2
+  filename          = local.zipfile
+  source_code_hash  = filebase64sha256(local.zipfile)
+  function_name     = "cloudwatch_event_rule_forwarder_euw2"
+  role              = aws_iam_role.cloudwatch_forwarder_role.arn
+  handler           = "lambda_handler.cloudwatch_event_rule_handler"
+  runtime           = "python3.7"
+  timeout           = 30
+  tags              = merge(module.tags.tags, map("Name", "cloudwatch_event_rule_forwarder_euw2_${data.aws_caller_identity.current.account_id}"))
+
+  environment {
+    variables = {
+      LOG_LEVEL         = var.LOG_LEVEL
+      PROD_ACCOUNT      = module.reference_accounts.production
+      TEST_ACCOUNT      = module.reference_accounts.staging
+      TARGET_ROLE       = var.TARGET_ROLE
+      TARGET_LAMBDA     = var.TARGET_LAMBDA
+      TARGET_SQS_QUEUE  = var.TARGET_SQS_QUEUE
+      TARGET_REGION     = var.TARGET_REGION
+      DEF_ENVIRONMENT   = var.DEF_ENVIRONMENT
+    }
+  }
+}
+
+resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw2_sns_invoke" {
+  statement_id  = "CloudForwarderCodepipelineAllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cloudwatch_event_rule_forwarder_euw2_lambda.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.euw2_cloudwatch_event_sns_topic.arn
+}
+
+resource "aws_sns_topic_subscription" "health_monitor_events_euw2_sns_subscription" {
+  topic_arn = aws_sns_topic.euw2_cloudwatch_event_sns_topic.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.cloudwatch_event_rule_forwarder_euw2_lambda.arn
 }

--- a/terraform/per_account/deployable/lambda_cloudwatch_event_rule_forwarder.tf
+++ b/terraform/per_account/deployable/lambda_cloudwatch_event_rule_forwarder.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_euw1_lambda" {
 }
 
 resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw1_sns_invoke" {
+  provider      = aws.eu-west-1
   statement_id  = "CloudForwarderCodepipelineAllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cloudwatch_event_rule_forwarder_euw1_lambda.function_name
@@ -32,6 +33,7 @@ resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw1_sns_invoke" {
 }
 
 resource "aws_sns_topic_subscription" "health_monitor_events_euw1_sns_subscription" {
+  provider  = aws.eu-west-1
   topic_arn = aws_sns_topic.euw1_cloudwatch_event_sns_topic.arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.cloudwatch_event_rule_forwarder_euw1_lambda.arn
@@ -64,6 +66,7 @@ resource "aws_lambda_function" "cloudwatch_event_rule_forwarder_euw2_lambda" {
 }
 
 resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw2_sns_invoke" {
+  provider      = aws.eu-west-2
   statement_id  = "CloudForwarderCodepipelineAllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cloudwatch_event_rule_forwarder_euw2_lambda.function_name
@@ -72,6 +75,7 @@ resource "aws_lambda_permission" "cloudwatch_forwarder_events_euw2_sns_invoke" {
 }
 
 resource "aws_sns_topic_subscription" "health_monitor_events_euw2_sns_subscription" {
+  provider  = aws.eu-west-2
   topic_arn = aws_sns_topic.euw2_cloudwatch_event_sns_topic.arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.cloudwatch_event_rule_forwarder_euw2_lambda.arn

--- a/terraform/per_account/deployable/sns.tf
+++ b/terraform/per_account/deployable/sns.tf
@@ -1,3 +1,4 @@
+# SNS for cloudwatch alarms
 locals {
   cloudwatch_alarm_sns_topic = "cloudwatch_forwarder"
 }
@@ -26,4 +27,35 @@ output "euw2_sns_arn" {
 locals {
   euw1_sns_cloudwatch_forwarder_topic = aws_sns_topic.euw1_cloudwatch_alarm_sns_topic.arn
   euw2_sns_cloudwatch_forwarder_topic = aws_sns_topic.euw2_cloudwatch_alarm_sns_topic.arn
+}
+
+# SNS for cloudwatch events
+locals {
+  cloudwatch_event_sns_topic = "cloudwatch_event_forwarder"
+}
+resource "aws_sns_topic" "euw1_cloudwatch_event_sns_topic" {
+  provider  = aws.eu-west-1
+  name      = local.cloudwatch_event_sns_topic
+  tags      = merge(module.tags.tags, map("Name", "euw1_cloudwatch_event_sns_topic_${data.aws_caller_identity.current.account_id}"))
+}
+
+output "euw1_sns_event_arn" {
+  value       = aws_sns_topic.euw1_cloudwatch_event_sns_topic.arn
+  description = "The ARNs for SNS topic"
+}
+
+resource "aws_sns_topic" "euw2_cloudwatch_event_sns_topic" {
+  provider  = aws.eu-west-2
+  name      = local.cloudwatch_event_sns_topic
+  tags      = merge(module.tags.tags, map("Name", "euw2_cloudwatch_event_sns_topic_${data.aws_caller_identity.current.account_id}"))
+}
+
+output "euw2_sns_event_arn" {
+  value       = aws_sns_topic.euw2_cloudwatch_event_sns_topic.arn
+  description = "The ARNs for SNS topics"
+}
+
+locals {
+  euw1_sns_cloudwatch_event_forwarder_topic = aws_sns_topic.euw1_cloudwatch_event_sns_topic.arn
+  euw2_sns_cloudwatch_event_forwarder_topic = aws_sns_topic.euw2_cloudwatch_event_sns_topic.arn
 }


### PR DESCRIPTION
Rather than subscribing to the codepipeline notification topic
.. instead subscribe to a generic cloudwatch event topic.

That way we can use this anywhere to forward cloudwatch events
from any service.

Then we need to change the codepipelines to get this topic as
a data resource and publish to it.