### PR TITLE
add namespace key to source message in event rule forwarder

### DIFF
--- a/lambda/health_package/cloudwatch_event_rule_forwarder.py
+++ b/lambda/health_package/cloudwatch_event_rule_forwarder.py
@@ -33,6 +33,7 @@ def cloudwatch_event_rule_to_standard_health_data_model(source_message):
     """
     LOG.info("source_message: %s", str(source_message))
     helper = enrich.get_namespace_helper(source_message.source)
+    source_message.Namespace = source_message.source
     source_message.Tags = helper.get_tags_for_metric_resource(source_message)
 
     event = HealthEvent()


### PR DESCRIPTION
I accidentally removed this line last week, but it is needed